### PR TITLE
Handle missing bundle identifier for Logger subsystem

### DIFF
--- a/NetPulse/Core/Logger+Extensions.swift
+++ b/NetPulse/Core/Logger+Extensions.swift
@@ -6,7 +6,7 @@ import OSLog
 
 extension Logger {
     // Используем bundleIdentifier, чтобы лог был уникальным для нашего приложения.
-    private static let subsystem = Bundle.main.bundleIdentifier!
+    private static let subsystem = Bundle.main.bundleIdentifier ?? "NetPulse"
 
     /// Логгер для общих событий жизненного цикла приложения.
     static let app = Logger(subsystem: subsystem, category: "Application")


### PR DESCRIPTION
## Summary
- Avoid force unwrapping the bundle identifier in logger extensions by providing a `NetPulse` fallback

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_689fccd1d7908325b66821cfbff5ba6e