### PR TITLE
Add SettingsManager validation tests and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Run unit tests
+      run: xcodebuild test -project NetPulse.xcodeproj -scheme NetPulse -destination 'platform=macOS'

--- a/NetPulse/Core/Managers/SettingsManager.swift
+++ b/NetPulse/Core/Managers/SettingsManager.swift
@@ -142,19 +142,19 @@ final class SettingsManager: ObservableObject {
         self.isCheckHostValid = validateHost(settings.checkHost)
     }
 
-    private func validateIP(_ address: String) -> Bool {
+    func validateIP(_ address: String) -> Bool {
         let pattern = #"^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$"#
         return address.range(of: pattern, options: .regularExpression) != nil
     }
 
-    private func validateHost(_ host: String) -> Bool {
+    func validateHost(_ host: String) -> Bool {
         if validateIP(host) { return true }
         // Паттерн для доменных имен.
         let pattern = #"^([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,6}$"#
         return host.range(of: pattern, options: .regularExpression) != nil
     }
     
-    private func validateSSHKey(_ path: String) -> Bool {
+    func validateSSHKey(_ path: String) -> Bool {
         guard !path.isEmpty else { return false }
         let expandedPath = (path as NSString).expandingTildeInPath
         var isDirectory: ObjCBool = false

--- a/NetPulseTests/SettingsManagerTests.swift
+++ b/NetPulseTests/SettingsManagerTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+@testable import NetPulse
+
+final class SettingsManagerTests: XCTestCase {
+    func testValidateIP() {
+        let manager = SettingsManager()
+        XCTAssertTrue(manager.validateIP("192.168.1.1"))
+        XCTAssertFalse(manager.validateIP("256.256.256.256"))
+    }
+
+    func testValidateHost() {
+        let manager = SettingsManager()
+        XCTAssertTrue(manager.validateHost("example.com"))
+        XCTAssertTrue(manager.validateHost("10.0.0.1"))
+        XCTAssertFalse(manager.validateHost(""))
+    }
+
+    func testValidateSSHKey() throws {
+        let manager = SettingsManager()
+        let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        FileManager.default.createFile(atPath: tempURL.path, contents: Data())
+        XCTAssertTrue(manager.validateSSHKey(tempURL.path))
+        try FileManager.default.removeItem(at: tempURL)
+        XCTAssertFalse(manager.validateSSHKey(tempURL.path))
+    }
+}


### PR DESCRIPTION
## Summary
- expose SettingsManager validation helpers for testing
- add unit tests for IP, host, and SSH key validation
- run tests in GitHub Actions macOS CI

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a075c3d6708325a2be69a3b30baca3